### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,9 +121,9 @@
 <table class="responsive">
 	<tr>
 		<th>Font</th>
-		<th>iOS</th>
+		<th>iOS 6</th>
 		<th>Android</th>
-		<th>WP7<sup>&#10013;</sup></th>
+		<th>WP7.1/8</th>
 	</tr>
 	<tr>
 		<td>Academy Engraved LET</td>
@@ -139,6 +139,12 @@
 	</tr>
 	<tr>
 		<td>Apple Color Emoji</td>
+				<td class="y">&#10003;</td>
+		<td></td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>AppleGothic Regular</td>
 				<td class="y">&#10003;</td>
 		<td></td>
 		<td></td>
@@ -174,6 +180,12 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>Arial Unicode MS</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
 		<td>Avenir</td>
 				<td class="y">&#10003;</td>
 		<td></td>
@@ -204,10 +216,10 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td>Bodoni Ornaments</td>
+		<td>Batang</td>
+		<td></td>
+		<td></td>
 				<td class="y">&#10003;</td>
-		<td></td>
-		<td></td>
 	</tr>
 	<tr>
 		<td>Bodoni 72</td>
@@ -222,16 +234,22 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td>Bradley Hand</td>
+		<td>Bodoni 72 Smallcaps</td>
 				<td class="y">&#10003;</td>
 		<td></td>
 		<td></td>
 	</tr>
 	<tr>
-		<td>Calibri</td>
-		<td></td>
-		<td></td>
+		<td>Bodoni Ornaments</td>
 				<td class="y">&#10003;</td>
+		<td></td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>Bradley Hand</td>
+				<td class="y">&#10003;</td>
+		<td></td>
+		<td></td>
 	</tr>
 	<tr>
 		<td>Chalkboard SE</td>
@@ -246,6 +264,30 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>Calibri</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Cambria</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Cambria Math</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Candara</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
 		<td>Cochin</td>
 				<td class="y">&#10003;</td>
 		<td></td>
@@ -258,10 +300,28 @@
 				<td class="y">&#10003;</td>
 	</tr>
 	<tr>
+		<td>Consolas</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Constantia</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
 		<td>Copperplate</td>
 				<td class="y">&#10003;</td>
 		<td></td>
 		<td></td>
+	</tr>
+	<tr>
+		<td>Corbel</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
 	</tr>
 	<tr>
 		<td>Courier</td>
@@ -408,16 +468,22 @@
 		<td></td>
 	</tr>
 	<tr>
-		<td>Malayalam Sangam MN</td>
+		<td>Lucida Grande</td>
+		<td></td>
+		<td></td>
 				<td class="y">&#10003;</td>
-		<td></td>
-		<td></td>
 	</tr>
 	<tr>
 		<td>Lucida Sans Unicode</td>
 		<td></td>
 		<td></td>
 				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Malayalam Sangam MN</td>
+				<td class="y">&#10003;</td>
+		<td></td>
+		<td></td>
 	</tr>
 	<tr>
 		<td>Marion</td>
@@ -430,6 +496,36 @@
 				<td class="y">&#10003;</td>
 		<td></td>
 		<td></td>
+	</tr>
+	<tr>
+		<td>Meiryo</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>MS Gothic</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>MS Mincho</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>MS PGothic</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>MS PMincho</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
 	</tr>
 	<tr>
 		<td>Noteworthy</td>
@@ -468,13 +564,25 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>PMingLiU</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
 		<td>Roboto</td>
 		<td></td>
 				<td class="y">&#10003;</td>
 		<td></td>
 	</tr>
 	<tr>
-		<td>Segoe WP</td>
+		<td>Segoe UI</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>SimSun</td>
 		<td></td>
 		<td></td>
 				<td class="y">&#10003;</td>
@@ -495,7 +603,7 @@
 		<td>Symbol</td>
 				<td class="y">&#10003;</td>
 		<td></td>
-		<td></td>
+				<td class="y">&#10003;</td>
 	</tr>
 	<tr>
 		<td>Tahoma</td>
@@ -540,7 +648,19 @@
 				<td class="y">&#10003;</td>
 	</tr>
 	<tr>
-		<td>Webdings</td>
+		<td>Wingdings</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Wingdings 2</td>
+		<td></td>
+		<td></td>
+				<td class="y">&#10003;</td>
+	</tr>
+	<tr>
+		<td>Wingdings 3</td>
 		<td></td>
 		<td></td>
 				<td class="y">&#10003;</td>
@@ -562,7 +682,7 @@
 <hr>
 
 <h2>Notes and Resources</h2>
-<p class="test"><sup>&#10013;</sup> I could only find resources for Windows Phone 7, I'm assuming the information is still current.
+<p class="test">Windows 7/8 fonts updated from <a href="http://msdn.microsoft.com/en-us/library/windowsphone/develop/cc189010%28v=vs.105%29.aspx#silverlight_fonts">Windows Phone Dev Center</a>
 <br>iOS fonts gathered from <a href="http://iosfonts.com/">http://iosfonts.com/</a>, Android fonts gathered after numerous fruitless searches, Windows Phone fonts mainly from <a href="blogs.msdn.com/b/iemobile/archive/2010/11/10/supported-fonts-on-ie-for-windows-phone-7.aspx">MSDN</a>
 <br>Where is Opera Mini you ask? It only serves one native sans-serif system font.
 <br>If any of the information above is incorrect or out of date &mdash; <a href="https://github.com/jordanmoore/tinytype">GitHub</a>.</p>


### PR DESCRIPTION
Corrected listing for Windows by adding missing fonts from http://msdn.microsoft.com/en-us/library/windowsphone/develop/cc189010%28v=vs.105%29.aspx#silverlight_fonts

Added in a few missing iOS fonts too, based on the "Typefaces" app which shows the actual installed fonts.
