### PR TITLE
Changed positive modifier for font compatibility from the letter x to a ...

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,14 +138,14 @@
   </tr>
   <tr>
     <td>Academy Engraved LET</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>American Typewriter</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -155,53 +155,53 @@
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Apple Color Emoji</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>AppleGothic Regular</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Apple SD Gothic Neo</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Arial</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Arial Black</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Arial Hebrew</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Arial Rounded MT Bold</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -210,40 +210,40 @@
     <td>Arial Unicode MS</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Avenir</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Avenir Next</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Avenir Next Condensed</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Bangla Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Baskerville</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -252,7 +252,7 @@
     <td>Batang</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
@@ -260,144 +260,144 @@
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBAlpha Sans Condensed</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBAlpha Serif</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBCAPITALS</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBCCasual</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBClarity</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBCondensed</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBGlobal Sans</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBGlobal Serif</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBMilbank</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBMilbank Tall</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBSansSerif</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBSansSerifSquare</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>BBSerifFixed</td>
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Bodoni 72</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Bodoni 72 Oldstyle</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Bodoni 72 Smallcaps</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Bodoni Ornaments</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Bradley Hand</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Chalkboard SE</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Chalkduster</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -406,33 +406,33 @@
     <td>Calibri</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Cambria</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Cambria Math</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Candara</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Cochin</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -441,26 +441,26 @@
     <td>Comic Sans MS</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Consolas</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Constantia</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Copperplate</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -469,40 +469,40 @@
     <td>Corbel</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Courier</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Courier New</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>DB LCD Temp</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Devanagari Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Didot</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -510,118 +510,118 @@
   <tr>
     <td>Droid Sans</td>
     <td></td>
-    <td class="y">x</td>
+    <td class="y">+</td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Droid Serif</td>
     <td></td>
-    <td class="y">x</td>
+    <td class="y">+</td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Droid Sans Mono</td>
     <td></td>
-    <td class="y">x</td>
+    <td class="y">+</td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Euphemia UCAS</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Futura</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Geeza Pro</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Georgia</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
       <td>Gill Sans</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
       <td>Gujarati Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
       <td>Gurmukhi MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
       <td>Heiti SC</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
       <td>Heiti TC</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Helvetica</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Helvetica Neue</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Hiragino Kaku Gothic ProN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Hiragino Mincho ProN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Hoefler Text</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -631,18 +631,18 @@
     <td></td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Kailasa</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Kannada Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -651,33 +651,33 @@
     <td>Lucida Grande</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Lucida Sans Unicode</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Malayalam Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Marion</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Marker Felt</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -686,75 +686,75 @@
     <td>Meiryo</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>MS Gothic</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>MS Mincho</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>MS PGothic</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>MS PMincho</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Noteworthy</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Optima</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Oriya Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Palatino</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Papyrus</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Party LET</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
@@ -763,13 +763,13 @@
     <td>PMingLiU</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Roboto</td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
   </tr>
@@ -777,117 +777,117 @@
     <td>Segoe UI</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>SimSun</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Sinhala Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Snell Roundhand</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Symbol</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Tahoma</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Tamil Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Telugu Sangam MN</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Thonburi</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Times New Roman</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Trebuchet MS</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Verdana</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
-        <td class="y">x</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
+        <td class="y">+</td>
   </tr>
   <tr>
     <td>Wingdings</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Wingdings 2</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Wingdings 3</td>
     <td></td>
     <td></td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
   </tr>
   <tr>
     <td>Zapf Dingbats</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>
   </tr>
   <tr>
     <td>Zapfino</td>
-        <td class="y">x</td>
+        <td class="y">+</td>
     <td></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
Minor (mostly cosmetic) change: changed the positive modifier symbol for when a font is present on a given platform from "x" to a "+" plus sign. Visually-impaired users cannot see the green background on table cells where a particular font is available and the "x" may be confusing; i.e. is this font available or not? The plus sign is really the only universal positive symbol available (check marks in some countries denote false).
